### PR TITLE
Limit dependencies to action-pack

### DIFF
--- a/actionpack-cloudflare.gemspec
+++ b/actionpack-cloudflare.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.add_runtime_dependency     'rails', '>= 3.2'
+  spec.add_runtime_dependency     'action-pack', '>= 3.2'
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'

--- a/actionpack-cloudflare.gemspec
+++ b/actionpack-cloudflare.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
-  spec.add_runtime_dependency     'action-pack', '>= 3.2'
+  spec.add_runtime_dependency     'actionpack', '>= 3.2'
   spec.add_development_dependency 'appraisal'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake'


### PR DESCRIPTION
Not all rails apps require all the gems. Since this gem only patches action-pack, it's runtime dependencies should be limited accordingly.
